### PR TITLE
Don't set nodejs_install_npm_user in test play…

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,7 +12,7 @@
 
 - name: Define nodejs_install_npm_user
   set_fact:
-    nodejs_install_npm_user: "{{ ansible_user }}"
+    nodejs_install_npm_user: "{{ ansible_user_id }}"
   when: nodejs_install_npm_user is not defined
 
 - name: get user facts for nodejs_install_npm_user

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -3,7 +3,7 @@
   become: true
   vars:
     nodejs_version: "11.x"
-    nodejs_install_npm_user: root
+    # nodejs_install_npm_user: root
     npm_config_prefix: /root/.npm-global
     npm_config_unsafe_perm: "true"
   roles:


### PR DESCRIPTION
…, to see if `ansible_user` still works (which this role falls back to). got errors when using this role that ansible_user is undefined.

Apparently this is a known issue, see https://github.com/ansible/ansible/issues/23530